### PR TITLE
Unicode translation modifier for erlang.string-template.value

### DIFF
--- a/Syntaxes/Erlang.xml
+++ b/Syntaxes/Erlang.xml
@@ -937,7 +937,13 @@
             <expression>\\\^?.?</expression>
           </scope>
           <scope name="erlang.string-template.value">
-            <expression>(~)((\-)?\d++|(\*))?((\.)(\d++|(\*)))?((\.)((\*)|.))?[~cfegswpWPBX#bx\+ni]</expression>
+            <expression>(~)((\-)?\d++|(\*))?((\.)(\d++|(\*)))?((\.)((\*)|.))?[lt]?p</expression>
+          </scope>
+          <scope name="erlang.string-template.value">
+            <expression>(~)((\-)?\d++|(\*))?((\.)(\d++|(\*)))?((\.)((\*)|.))?t?[csw]</expression>
+          </scope>
+          <scope name="erlang.string-template.value">
+            <expression>(~)((\-)?\d++|(\*))?((\.)(\d++|(\*)))?((\.)((\*)|.))?[~fegWPBX#bx\+ni]</expression>
           </scope>
           <scope name="erlang.string-template.value">
             <expression>(~)(\*)?(\d++)?[~du\-#fsacl]</expression>


### PR DESCRIPTION
Adds support for Unicode translation and printable character lists suppression modifiers within `erlang.string-template.value`. Previously, `io:format` control sequences with modifiers were treated as `erlang.invalid.string` or ignored. This should now cover all formats found at http://erlang.org/doc/man/io.html#format-3 — a before and after example:

![erlang](https://user-images.githubusercontent.com/440067/102520837-c0739780-4059-11eb-8c67-bb13f9d703f3.png)